### PR TITLE
add input or output SID when defined

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -602,7 +602,9 @@ class SidFile:
                 self.merge_item('data', "/%s:%s" % (self.module_name, statement.arg))
                 for substmt in statement.i_children:
                     if substmt.keyword in self.inrpc_keywords:
-                        self.collect_inner_data_nodes(substmt.i_children)
+                        if len(substmt.i_children) > 0:
+                            self.merge_item('data', "/%s:%s/%s" % (self.module_name, statement.arg, substmt.keyword))
+                            self.collect_inner_data_nodes(substmt.i_children)
 
             elif statement.keyword == 'notification':
                 self.merge_item('data', "/%s:%s" % (self.module_name, statement.arg))


### PR DESCRIPTION
add the SID for input or output when defined in the data model.

for instance:

pyang -p yang/standard/ietf --sid-generate-file=1700:300 --sid-list ietf-system@2014-08-06.yang

SID        Assigned to
---------  --------------------------------------------------
1700       module ietf-system
1701       identity authentication-method
1702       identity local-users
1703       identity radius
1704       identity radius-authentication-type
1705       identity radius-chap
1706       identity radius-pap
1707       feature authentication
1708       feature dns-udp-tcp-port
1709       feature local-users
1710       feature ntp
1711       feature ntp-udp-port
1712       feature radius
1713       feature radius-authentication
1714       feature timezone-name
1715       data /ietf-system:set-current-datetime
**1716       data /ietf-system:set-current-datetime/input**
1717       data /ietf-system:set-current-datetime/input/current-datetime
1718       data /ietf-system:system
1719       data /ietf-system:system-restart
1720       data /ietf-system:system-shutdown
...