### PR TITLE
Sid sx structure 2.7.1

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -566,6 +566,15 @@ class SidFile:
     def has_yang_data_extension(statement):
         try:
             return statement.i_extension.arg == 'yang-data'
+
+        except AttributeError:
+            return False
+
+    @staticmethod
+    def has_structure_extension(statement):
+        try:
+            return statement.i_extension.arg == 'structure'
+
         except AttributeError:
             return False
 
@@ -615,6 +624,8 @@ class SidFile:
             if substmt.keyword == 'augment':
                 self.collect_in_substmts(substmt.substmts)
             elif self.has_yang_data_extension(substmt):
+                self.collect_in_substmts(substmt.substmts)
+            elif self.has_structure_extension(substmt):
                 self.collect_in_substmts(substmt.substmts)
 
     def collect_inner_data_nodes(self, statements, prefix=""):

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -690,8 +690,11 @@ class SidFile:
         return prefix + path
 
     def merge_item(self, namespace, identifier):
+        # only compare the last component.
+        lastid = re.split(r'[/:]', identifier)[-1]
         for item in self.content['items']:
-            if (namespace == item['namespace'] and identifier == item['identifier']):
+            itemlast = re.split(r'[/:]',item['identifier'])[-1]
+            if (namespace == item['namespace'] and lastid == itemlast):
                 item['lifecycle'] = 'o' # Item already assigned
                 return
         self.content['items'].append(collections.OrderedDict(


### PR DESCRIPTION
This commit rebases the work done in 2023 to add support for sx:structure.
This also includes a change to compare on the last component of each path, which may be more controversial, but is necessary if SID values are to remain stable despite changes in choice.
