### PR TITLE
Core fix submod name

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -182,6 +182,7 @@ YANG Schema Item iDentifiers (SID) are globally unique unsigned integers used
 to identify YANG items. SIDs are used instead of names to save space in
 constrained applications such as COREconf. This plugin is used to automatically
 generate and updated .sid files used to persist and distribute SID assignments.
+Note that the yang-filename must contain a YANG module not a YANG submodule.
 
 
 COMMANDS
@@ -324,6 +325,10 @@ class SidFile:
         self.update = False
 
     def process_sid_file(self, module):
+        # SID are assigned in context of one namespace, the module defines new namespace.
+        # All submodule live in the parent namespace.
+        if module.keyword == 'submodule':
+            raise SidParsingError(".sid files can be only generated for YANG modules. Generation of .sid files for YANG submodules is prohibited.")
         self.module_name = module.i_modulename
         self.module_revision = util.get_latest_revision(module)
         if self.module_revision != 'unknown':
@@ -710,9 +715,10 @@ class SidFile:
 
         self.merge_item('module', self.module_name)
 
-        for name in module.i_ctx.modules:
-            if module.i_ctx.modules[name].keyword == 'submodule':
-                self.merge_item('module', module.i_ctx.modules[name].arg)
+        # do not generate SIDs for submodules
+        #for name in module.i_ctx.modules:
+        #    if module.i_ctx.modules[name].keyword == 'submodule':
+        #        self.merge_item('module', module.i_ctx.modules[name].arg)
 
         for feature in module.i_features:
             self.merge_item('feature', feature)
@@ -830,8 +836,6 @@ class SidFile:
     def get_path(self, statement, prefix=""):
         path = ""
 
-        #breakpoint()
-
         while statement.i_module is not None:
             if (statement.keyword != 'grouping'
                     and not self.has_yang_data_extension(statement)):
@@ -851,14 +855,14 @@ class SidFile:
 
                 if (prefix != "" or
                         (parent.i_module is not None and
-                         parent.i_module == statement.i_module) or
+                         parent.main_module() == statement.main_module()) or
                         (statement.keyword == 'case' and 
-                         statement.i_module == statement.parent.i_module) or
+                         statement.main_module() == statement.parent.main_module()) or
                         (statement.parent.keyword == 'case' and 
-                         statement.i_module == statement.parent.i_module)):
+                         statement.main_module() == statement.parent.main_module())):
                     path = "/" + statement.arg + path
                 else:
-                    path = "/" + statement.i_module.arg + ":" + statement.arg \
+                    path = "/" + statement.main_module().arg + ":" + statement.arg \
                             + path
 
             statement = statement.parent

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -715,10 +715,9 @@ class SidFile:
 
         self.merge_item('module', self.module_name)
 
-        # do not generate SIDs for submodules
-        #for name in module.i_ctx.modules:
-        #    if module.i_ctx.modules[name].keyword == 'submodule':
-        #        self.merge_item('module', module.i_ctx.modules[name].arg)
+        for name in module.i_ctx.modules:
+            if module.i_ctx.modules[name].keyword == 'submodule':
+                self.merge_item('module', module.i_ctx.modules[name].arg)
 
         for feature in module.i_features:
             self.merge_item('feature', feature)

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -2,10 +2,12 @@ PYANG?= pyang
 
 .PHONY: test test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 test23 \
-	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34 \
+	test39 test40
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 \
-	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 \
+	test33 test34 test39 test40
 
 test1:
 	# Test help
@@ -195,4 +197,25 @@ test34: aug-a@2025-08-25.yang aug-b@2025-08-25.yang aug-c@2025-08-25.yang test-3
 	$(PYANG) --sid-generate-file 1200:100 aug-c@2025-08-25.yang --sid-finalize >/dev/null 2>/dev/null
 	diff -b aug-c@2025-08-25.sid test-34-expected-aug-c.sid
 	rm aug-a@2025-08-25.sid aug-b@2025-08-25.sid aug-c@2025-08-25.sid
+
+IETF_SNMP = ../../modules/ietf/ietf-snmp.yang
+IETF_SNMP_COMMON = ../../modules/ietf/ietf-snmp-common.yang
+IETF_SNMP_ENGINE = ../../modules/ietf/ietf-snmp-engine.yang
+IETF_SNMP_TARGET = ../../modules/ietf/ietf-snmp-target.yang
+IETF_SNMP_NOTIFICATION = ../../modules/ietf/ietf-snmp-notification.yang
+IETF_SNMP_PROXY = ../../modules/ietf/ietf-snmp-proxy.yang
+IETF_SNMP_COMMUNITY = ../../modules/ietf/ietf-snmp-community.yang
+IETF_SNMP_USM = ../../modules/ietf/ietf-snmp-usm.yang
+IETF_SNMP_TSM = ../../modules/ietf/ietf-snmp-tsm.yang
+IETF_SNMP_VACM = ../../modules/ietf/ietf-snmp-vacm.yang
+IETF_SNMP_TLS = ../../modules/ietf/ietf-snmp-tls.yang
+IETF_SNMP_SSH = ../../modules/ietf/ietf-snmp-ssh.yang
+
+test39: $(IETF_SNMP) $(IETF_SNMP_COMMON) $(IETF_SNMP_ENGINE) $(IETF_SNMP_TARGET) $(IETF_SNMP_NOTIFICATION) $(IETF_SNMP_PROXY) $(IETF_SNMP_COMMUNITY) $(IETF_SNMP_USM) $(IETF_SNMP_TSM) $(IETF_SNMP_VACM) $(IETF_SNMP_TLS) $(IETF_SNMP_SSH)
+	$(PYANG) --sid-generate-file 60000:1000 $(IETF_SNMP) 2>&1 >/dev/null
+	diff -b ietf-snmp@2014-12-10.sid test-39-expected-ietf-snmp@2014-12-10.sid
+	rm ietf-snmp@2014-12-10.sid
+
+test40: $(IETF_SNMP_COMMON)
+	$(PYANG) --sid-generate-file 61000:1000 $(IETF_SNMP_COMMON) 2>&1 | diff -b test-40-expected-output.txt -
 

--- a/test/test_sid/test-1-expected-output.txt
+++ b/test/test_sid/test-1-expected-output.txt
@@ -3,6 +3,7 @@ YANG Schema Item iDentifiers (SID) are globally unique unsigned integers used
 to identify YANG items. SIDs are used instead of names to save space in
 constrained applications such as COREconf. This plugin is used to automatically
 generate and updated .sid files used to persist and distribute SID assignments.
+Note that the yang-filename must contain a YANG module not a YANG submodule.
 
 
 COMMANDS
@@ -50,7 +51,7 @@ OPTIONS
 
   $ pyang --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang
 
--- sid-check-file
+--sid-check-file
 
   The --sid-check-file option can be used at any time to verify if a .sid file
   need to be updated.
@@ -61,6 +62,11 @@ OPTIONS
   For example:
 
   $ pyang --sid-check-file toaster@2009-12-28.sid toaster@2009-12-28.yang
+
+--sid-extension
+
+   Add non standard entries in the .sid file to facilitate CORECONF manipulation
+   on constrained devices. 
 
 --sid-list
 

--- a/test/test_sid/test-39-expected-ietf-snmp@2014-12-10.sid
+++ b/test/test_sid/test-39-expected-ietf-snmp@2014-12-10.sid
@@ -1,0 +1,1077 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "ietf-snmp",
+    "module-revision": "2014-12-10",
+    "sid-file-status": "unpublished",
+    "assignment-range": [
+      {
+        "entry-point": "60000",
+        "size": "1000"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "ietf-snmp",
+        "status": "unstable",
+        "sid": "60000"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "notification-filter",
+        "status": "unstable",
+        "sid": "60001"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "proxy",
+        "status": "unstable",
+        "sid": "60002"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "sshtm",
+        "status": "unstable",
+        "sid": "60003"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "tlstm",
+        "status": "unstable",
+        "sid": "60004"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "tsm",
+        "status": "unstable",
+        "sid": "60005"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp",
+        "status": "unstable",
+        "sid": "60006"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community",
+        "status": "unstable",
+        "sid": "60007"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/context",
+        "status": "unstable",
+        "sid": "60008"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/engine-id",
+        "status": "unstable",
+        "sid": "60009"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/index",
+        "status": "unstable",
+        "sid": "60010"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/name",
+        "status": "unstable",
+        "sid": "60011"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/name/binary-name",
+        "status": "unstable",
+        "sid": "60012"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/name/binary-name/binary-name",
+        "status": "unstable",
+        "sid": "60013"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/name/text-name",
+        "status": "unstable",
+        "sid": "60014"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/name/text-name/text-name",
+        "status": "unstable",
+        "sid": "60015"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/security-name",
+        "status": "unstable",
+        "sid": "60016"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/community/target-tag",
+        "status": "unstable",
+        "sid": "60017"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine",
+        "status": "unstable",
+        "sid": "60018"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/enable-authen-traps",
+        "status": "unstable",
+        "sid": "60019"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/enabled",
+        "status": "unstable",
+        "sid": "60020"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/engine-id",
+        "status": "unstable",
+        "sid": "60021"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen",
+        "status": "unstable",
+        "sid": "60022"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/name",
+        "status": "unstable",
+        "sid": "60023"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport",
+        "status": "unstable",
+        "sid": "60024"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls",
+        "status": "unstable",
+        "sid": "60025"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls/dtls",
+        "status": "unstable",
+        "sid": "60026"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls/dtls/ip",
+        "status": "unstable",
+        "sid": "60027"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls/dtls/port",
+        "status": "unstable",
+        "sid": "60028"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh",
+        "status": "unstable",
+        "sid": "60029"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh/ssh",
+        "status": "unstable",
+        "sid": "60030"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh/ssh/ip",
+        "status": "unstable",
+        "sid": "60031"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh/ssh/port",
+        "status": "unstable",
+        "sid": "60032"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls",
+        "status": "unstable",
+        "sid": "60033"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls/tls",
+        "status": "unstable",
+        "sid": "60034"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls/tls/ip",
+        "status": "unstable",
+        "sid": "60035"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls/tls/port",
+        "status": "unstable",
+        "sid": "60036"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp",
+        "status": "unstable",
+        "sid": "60037"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp/udp",
+        "status": "unstable",
+        "sid": "60038"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp/udp/ip",
+        "status": "unstable",
+        "sid": "60039"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp/udp/port",
+        "status": "unstable",
+        "sid": "60040"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/version",
+        "status": "unstable",
+        "sid": "60041"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/version/v1",
+        "status": "unstable",
+        "sid": "60042"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/version/v2c",
+        "status": "unstable",
+        "sid": "60043"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/engine/version/v3",
+        "status": "unstable",
+        "sid": "60044"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify",
+        "status": "unstable",
+        "sid": "60045"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify-filter-profile",
+        "status": "unstable",
+        "sid": "60046"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify-filter-profile/exclude",
+        "status": "unstable",
+        "sid": "60047"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify-filter-profile/include",
+        "status": "unstable",
+        "sid": "60048"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify-filter-profile/name",
+        "status": "unstable",
+        "sid": "60049"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify/name",
+        "status": "unstable",
+        "sid": "60050"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify/tag",
+        "status": "unstable",
+        "sid": "60051"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/notify/type",
+        "status": "unstable",
+        "sid": "60052"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy",
+        "status": "unstable",
+        "sid": "60053"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/context-engine-id",
+        "status": "unstable",
+        "sid": "60054"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/context-name",
+        "status": "unstable",
+        "sid": "60055"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/multiple-target-out",
+        "status": "unstable",
+        "sid": "60056"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/name",
+        "status": "unstable",
+        "sid": "60057"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/single-target-out",
+        "status": "unstable",
+        "sid": "60058"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/target-params-in",
+        "status": "unstable",
+        "sid": "60059"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/proxy/type",
+        "status": "unstable",
+        "sid": "60060"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target",
+        "status": "unstable",
+        "sid": "60061"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params",
+        "status": "unstable",
+        "sid": "60062"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/name",
+        "status": "unstable",
+        "sid": "60063"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/notify-filter-profile",
+        "status": "unstable",
+        "sid": "60064"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params",
+        "status": "unstable",
+        "sid": "60065"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/tsm",
+        "status": "unstable",
+        "sid": "60066"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/tsm/tsm",
+        "status": "unstable",
+        "sid": "60067"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/tsm/tsm/security-level",
+        "status": "unstable",
+        "sid": "60068"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/tsm/tsm/security-name",
+        "status": "unstable",
+        "sid": "60069"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/usm",
+        "status": "unstable",
+        "sid": "60070"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/usm/usm",
+        "status": "unstable",
+        "sid": "60071"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/usm/usm/security-level",
+        "status": "unstable",
+        "sid": "60072"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/usm/usm/user-name",
+        "status": "unstable",
+        "sid": "60073"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/v1",
+        "status": "unstable",
+        "sid": "60074"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/v1/v1",
+        "status": "unstable",
+        "sid": "60075"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/v1/v1/security-name",
+        "status": "unstable",
+        "sid": "60076"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/v2c",
+        "status": "unstable",
+        "sid": "60077"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/v2c/v2c",
+        "status": "unstable",
+        "sid": "60078"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target-params/params/v2c/v2c/security-name",
+        "status": "unstable",
+        "sid": "60079"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/mms",
+        "status": "unstable",
+        "sid": "60080"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/name",
+        "status": "unstable",
+        "sid": "60081"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/retries",
+        "status": "unstable",
+        "sid": "60082"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/tag",
+        "status": "unstable",
+        "sid": "60083"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/target-params",
+        "status": "unstable",
+        "sid": "60084"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/timeout",
+        "status": "unstable",
+        "sid": "60085"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport",
+        "status": "unstable",
+        "sid": "60086"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls",
+        "status": "unstable",
+        "sid": "60087"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls",
+        "status": "unstable",
+        "sid": "60088"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/client-fingerprint",
+        "status": "unstable",
+        "sid": "60089"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/ip",
+        "status": "unstable",
+        "sid": "60090"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/port",
+        "status": "unstable",
+        "sid": "60091"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/server-fingerprint",
+        "status": "unstable",
+        "sid": "60092"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/server-identity",
+        "status": "unstable",
+        "sid": "60093"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/ssh",
+        "status": "unstable",
+        "sid": "60094"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh",
+        "status": "unstable",
+        "sid": "60095"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh/ip",
+        "status": "unstable",
+        "sid": "60096"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh/port",
+        "status": "unstable",
+        "sid": "60097"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh/username",
+        "status": "unstable",
+        "sid": "60098"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls",
+        "status": "unstable",
+        "sid": "60099"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls/tls",
+        "status": "unstable",
+        "sid": "60100"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/client-fingerprint",
+        "status": "unstable",
+        "sid": "60101"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/ip",
+        "status": "unstable",
+        "sid": "60102"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/port",
+        "status": "unstable",
+        "sid": "60103"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/server-fingerprint",
+        "status": "unstable",
+        "sid": "60104"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/server-identity",
+        "status": "unstable",
+        "sid": "60105"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/udp",
+        "status": "unstable",
+        "sid": "60106"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/udp/udp",
+        "status": "unstable",
+        "sid": "60107"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/udp/udp/ip",
+        "status": "unstable",
+        "sid": "60108"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/udp/udp/port",
+        "status": "unstable",
+        "sid": "60109"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/target/transport/udp/udp/prefix-length",
+        "status": "unstable",
+        "sid": "60110"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tlstm",
+        "status": "unstable",
+        "sid": "60111"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name",
+        "status": "unstable",
+        "sid": "60112"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/fingerprint",
+        "status": "unstable",
+        "sid": "60113"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/id",
+        "status": "unstable",
+        "sid": "60114"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/map-type",
+        "status": "unstable",
+        "sid": "60115"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/name",
+        "status": "unstable",
+        "sid": "60116"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tsm",
+        "status": "unstable",
+        "sid": "60117"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/tsm/use-prefix",
+        "status": "unstable",
+        "sid": "60118"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm",
+        "status": "unstable",
+        "sid": "60119"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local",
+        "status": "unstable",
+        "sid": "60120"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user",
+        "status": "unstable",
+        "sid": "60121"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth",
+        "status": "unstable",
+        "sid": "60122"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol",
+        "status": "unstable",
+        "sid": "60123"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/md5",
+        "status": "unstable",
+        "sid": "60124"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/md5/md5",
+        "status": "unstable",
+        "sid": "60125"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/md5/md5/key",
+        "status": "unstable",
+        "sid": "60126"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/sha",
+        "status": "unstable",
+        "sid": "60127"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/sha/sha",
+        "status": "unstable",
+        "sid": "60128"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/sha/sha/key",
+        "status": "unstable",
+        "sid": "60129"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/name",
+        "status": "unstable",
+        "sid": "60130"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv",
+        "status": "unstable",
+        "sid": "60131"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol",
+        "status": "unstable",
+        "sid": "60132"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/aes",
+        "status": "unstable",
+        "sid": "60133"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/aes/aes",
+        "status": "unstable",
+        "sid": "60134"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/aes/aes/key",
+        "status": "unstable",
+        "sid": "60135"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/des",
+        "status": "unstable",
+        "sid": "60136"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/des/des",
+        "status": "unstable",
+        "sid": "60137"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/des/des/key",
+        "status": "unstable",
+        "sid": "60138"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote",
+        "status": "unstable",
+        "sid": "60139"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/engine-id",
+        "status": "unstable",
+        "sid": "60140"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user",
+        "status": "unstable",
+        "sid": "60141"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth",
+        "status": "unstable",
+        "sid": "60142"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol",
+        "status": "unstable",
+        "sid": "60143"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/md5",
+        "status": "unstable",
+        "sid": "60144"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/md5/md5",
+        "status": "unstable",
+        "sid": "60145"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/md5/md5/key",
+        "status": "unstable",
+        "sid": "60146"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/sha",
+        "status": "unstable",
+        "sid": "60147"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/sha/sha",
+        "status": "unstable",
+        "sid": "60148"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/sha/sha/key",
+        "status": "unstable",
+        "sid": "60149"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/name",
+        "status": "unstable",
+        "sid": "60150"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv",
+        "status": "unstable",
+        "sid": "60151"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol",
+        "status": "unstable",
+        "sid": "60152"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/aes",
+        "status": "unstable",
+        "sid": "60153"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/aes/aes",
+        "status": "unstable",
+        "sid": "60154"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/aes/aes/key",
+        "status": "unstable",
+        "sid": "60155"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/des",
+        "status": "unstable",
+        "sid": "60156"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/des/des",
+        "status": "unstable",
+        "sid": "60157"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/des/des/key",
+        "status": "unstable",
+        "sid": "60158"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm",
+        "status": "unstable",
+        "sid": "60159"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group",
+        "status": "unstable",
+        "sid": "60160"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access",
+        "status": "unstable",
+        "sid": "60161"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/context",
+        "status": "unstable",
+        "sid": "60162"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/context-match",
+        "status": "unstable",
+        "sid": "60163"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/notify-view",
+        "status": "unstable",
+        "sid": "60164"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/read-view",
+        "status": "unstable",
+        "sid": "60165"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/security-level",
+        "status": "unstable",
+        "sid": "60166"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/security-model",
+        "status": "unstable",
+        "sid": "60167"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/access/write-view",
+        "status": "unstable",
+        "sid": "60168"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/member",
+        "status": "unstable",
+        "sid": "60169"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/member/security-model",
+        "status": "unstable",
+        "sid": "60170"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/member/security-name",
+        "status": "unstable",
+        "sid": "60171"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/group/name",
+        "status": "unstable",
+        "sid": "60172"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/view",
+        "status": "unstable",
+        "sid": "60173"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/view/exclude",
+        "status": "unstable",
+        "sid": "60174"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/view/include",
+        "status": "unstable",
+        "sid": "60175"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-snmp:snmp/vacm/view/name",
+        "status": "unstable",
+        "sid": "60176"
+      }
+    ]
+  }
+}

--- a/test/test_sid/test-39-expected-ietf-snmp@2014-12-10.sid
+++ b/test/test_sid/test-39-expected-ietf-snmp@2014-12-10.sid
@@ -17,1060 +17,1126 @@
         "sid": "60000"
       },
       {
+	"namespace": "module",
+	"identifier": "ietf-snmp-common",
+	"status": "unstable",
+	"sid": "60001"
+      },
+      {
+	"namespace": "module",
+        "identifier": "ietf-snmp-community",
+	"status": "unstable",
+	"sid": "60002"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-engine",
+	"status": "unstable",
+	"sid": "60003"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-notification",
+	"status": "unstable",
+	"sid": "60004"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-proxy",
+	"status": "unstable",
+	"sid": "60005"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-ssh",
+	"status": "unstable",
+	"sid": "60006"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-target",
+	"status": "unstable",
+	"sid": "60007"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-tls",
+	"status": "unstable",
+	"sid": "60008"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-tsm",
+	"status": "unstable",
+	"sid": "60009"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-usm",
+	"status": "unstable",
+	"sid": "60010"
+      },
+      {
+	"namespace": "module",
+	"identifier": "ietf-snmp-vacm",
+	"status": "unstable",
+	"sid": "60011"
+      },
+      {
         "namespace": "feature",
         "identifier": "notification-filter",
         "status": "unstable",
-        "sid": "60001"
+	"sid": "60012"
       },
       {
         "namespace": "feature",
         "identifier": "proxy",
         "status": "unstable",
-        "sid": "60002"
+	"sid": "60013"
       },
       {
         "namespace": "feature",
         "identifier": "sshtm",
         "status": "unstable",
-        "sid": "60003"
+	"sid": "60014"
       },
       {
         "namespace": "feature",
         "identifier": "tlstm",
         "status": "unstable",
-        "sid": "60004"
+	"sid": "60015"
       },
       {
         "namespace": "feature",
         "identifier": "tsm",
         "status": "unstable",
-        "sid": "60005"
+	"sid": "60016"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp",
         "status": "unstable",
-        "sid": "60006"
+	"sid": "60017"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community",
         "status": "unstable",
-        "sid": "60007"
+	"sid": "60018"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/context",
         "status": "unstable",
-        "sid": "60008"
+	"sid": "60019"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/engine-id",
         "status": "unstable",
-        "sid": "60009"
+	"sid": "60020"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/index",
         "status": "unstable",
-        "sid": "60010"
+	"sid": "60021"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/name",
         "status": "unstable",
-        "sid": "60011"
+	"sid": "60022"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/name/binary-name",
         "status": "unstable",
-        "sid": "60012"
+	"sid": "60023"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/name/binary-name/binary-name",
         "status": "unstable",
-        "sid": "60013"
+	"sid": "60024"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/name/text-name",
         "status": "unstable",
-        "sid": "60014"
+	"sid": "60025"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/name/text-name/text-name",
         "status": "unstable",
-        "sid": "60015"
+	"sid": "60026"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/security-name",
         "status": "unstable",
-        "sid": "60016"
+	"sid": "60027"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/community/target-tag",
         "status": "unstable",
-        "sid": "60017"
+	"sid": "60028"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine",
         "status": "unstable",
-        "sid": "60018"
+	"sid": "60029"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/enable-authen-traps",
         "status": "unstable",
-        "sid": "60019"
+	"sid": "60030"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/enabled",
         "status": "unstable",
-        "sid": "60020"
+	"sid": "60031"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/engine-id",
         "status": "unstable",
-        "sid": "60021"
+	"sid": "60032"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen",
         "status": "unstable",
-        "sid": "60022"
+	"sid": "60033"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/name",
         "status": "unstable",
-        "sid": "60023"
+	"sid": "60034"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport",
         "status": "unstable",
-        "sid": "60024"
+	"sid": "60035"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls",
         "status": "unstable",
-        "sid": "60025"
+	"sid": "60036"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls/dtls",
         "status": "unstable",
-        "sid": "60026"
+	"sid": "60037"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls/dtls/ip",
         "status": "unstable",
-        "sid": "60027"
+	"sid": "60038"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/dtls/dtls/port",
         "status": "unstable",
-        "sid": "60028"
+	"sid": "60039"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh",
         "status": "unstable",
-        "sid": "60029"
+	"sid": "60040"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh/ssh",
         "status": "unstable",
-        "sid": "60030"
+	"sid": "60041"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh/ssh/ip",
         "status": "unstable",
-        "sid": "60031"
+	"sid": "60042"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/ssh/ssh/port",
         "status": "unstable",
-        "sid": "60032"
+	"sid": "60043"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls",
         "status": "unstable",
-        "sid": "60033"
+	"sid": "60044"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls/tls",
         "status": "unstable",
-        "sid": "60034"
+	"sid": "60045"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls/tls/ip",
         "status": "unstable",
-        "sid": "60035"
+	"sid": "60046"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/tls/tls/port",
         "status": "unstable",
-        "sid": "60036"
+	"sid": "60047"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp",
         "status": "unstable",
-        "sid": "60037"
+	"sid": "60048"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp/udp",
         "status": "unstable",
-        "sid": "60038"
+	"sid": "60049"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp/udp/ip",
         "status": "unstable",
-        "sid": "60039"
+	"sid": "60050"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/listen/transport/udp/udp/port",
         "status": "unstable",
-        "sid": "60040"
+	"sid": "60051"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/version",
         "status": "unstable",
-        "sid": "60041"
+	"sid": "60052"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/version/v1",
         "status": "unstable",
-        "sid": "60042"
+	"sid": "60053"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/version/v2c",
         "status": "unstable",
-        "sid": "60043"
+	"sid": "60054"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/engine/version/v3",
         "status": "unstable",
-        "sid": "60044"
+	"sid": "60055"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify",
         "status": "unstable",
-        "sid": "60045"
+	"sid": "60056"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify-filter-profile",
         "status": "unstable",
-        "sid": "60046"
+	"sid": "60057"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify-filter-profile/exclude",
         "status": "unstable",
-        "sid": "60047"
+	"sid": "60058"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify-filter-profile/include",
         "status": "unstable",
-        "sid": "60048"
+	"sid": "60059"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify-filter-profile/name",
         "status": "unstable",
-        "sid": "60049"
+	"sid": "60060"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify/name",
         "status": "unstable",
-        "sid": "60050"
+	"sid": "60061"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify/tag",
         "status": "unstable",
-        "sid": "60051"
+	"sid": "60062"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/notify/type",
         "status": "unstable",
-        "sid": "60052"
+	"sid": "60063"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy",
         "status": "unstable",
-        "sid": "60053"
+	"sid": "60064"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/context-engine-id",
         "status": "unstable",
-        "sid": "60054"
+	"sid": "60065"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/context-name",
         "status": "unstable",
-        "sid": "60055"
+	"sid": "60066"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/multiple-target-out",
         "status": "unstable",
-        "sid": "60056"
+	"sid": "60067"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/name",
         "status": "unstable",
-        "sid": "60057"
+	"sid": "60068"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/single-target-out",
         "status": "unstable",
-        "sid": "60058"
+	"sid": "60069"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/target-params-in",
         "status": "unstable",
-        "sid": "60059"
+	"sid": "60070"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/proxy/type",
         "status": "unstable",
-        "sid": "60060"
+	"sid": "60071"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target",
         "status": "unstable",
-        "sid": "60061"
+	"sid": "60072"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params",
         "status": "unstable",
-        "sid": "60062"
+	"sid": "60073"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/name",
         "status": "unstable",
-        "sid": "60063"
+	"sid": "60074"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/notify-filter-profile",
         "status": "unstable",
-        "sid": "60064"
+	"sid": "60075"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params",
         "status": "unstable",
-        "sid": "60065"
+	"sid": "60076"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/tsm",
         "status": "unstable",
-        "sid": "60066"
+	"sid": "60077"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/tsm/tsm",
         "status": "unstable",
-        "sid": "60067"
+	"sid": "60078"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/tsm/tsm/security-level",
         "status": "unstable",
-        "sid": "60068"
+	"sid": "60079"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/tsm/tsm/security-name",
         "status": "unstable",
-        "sid": "60069"
+	"sid": "60080"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/usm",
         "status": "unstable",
-        "sid": "60070"
+	"sid": "60081"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/usm/usm",
         "status": "unstable",
-        "sid": "60071"
+	"sid": "60082"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/usm/usm/security-level",
         "status": "unstable",
-        "sid": "60072"
+	"sid": "60083"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/usm/usm/user-name",
         "status": "unstable",
-        "sid": "60073"
+	"sid": "60084"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/v1",
         "status": "unstable",
-        "sid": "60074"
+	"sid": "60085"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/v1/v1",
         "status": "unstable",
-        "sid": "60075"
+	"sid": "60086"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/v1/v1/security-name",
         "status": "unstable",
-        "sid": "60076"
+	"sid": "60087"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/v2c",
         "status": "unstable",
-        "sid": "60077"
+	"sid": "60088"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/v2c/v2c",
         "status": "unstable",
-        "sid": "60078"
+	"sid": "60089"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target-params/params/v2c/v2c/security-name",
         "status": "unstable",
-        "sid": "60079"
+	"sid": "60090"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/mms",
         "status": "unstable",
-        "sid": "60080"
+	"sid": "60091"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/name",
         "status": "unstable",
-        "sid": "60081"
+	"sid": "60092"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/retries",
         "status": "unstable",
-        "sid": "60082"
+	"sid": "60093"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/tag",
         "status": "unstable",
-        "sid": "60083"
+	"sid": "60094"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/target-params",
         "status": "unstable",
-        "sid": "60084"
+	"sid": "60095"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/timeout",
         "status": "unstable",
-        "sid": "60085"
+	"sid": "60096"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport",
         "status": "unstable",
-        "sid": "60086"
+	"sid": "60097"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls",
         "status": "unstable",
-        "sid": "60087"
+	"sid": "60098"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls",
         "status": "unstable",
-        "sid": "60088"
+	"sid": "60099"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/client-fingerprint",
         "status": "unstable",
-        "sid": "60089"
+	"sid": "60100"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/ip",
         "status": "unstable",
-        "sid": "60090"
+	"sid": "60101"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/port",
         "status": "unstable",
-        "sid": "60091"
+	"sid": "60102"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/server-fingerprint",
         "status": "unstable",
-        "sid": "60092"
+	"sid": "60103"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/dtls/dtls/server-identity",
         "status": "unstable",
-        "sid": "60093"
+	"sid": "60104"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/ssh",
         "status": "unstable",
-        "sid": "60094"
+	"sid": "60105"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh",
         "status": "unstable",
-        "sid": "60095"
+	"sid": "60106"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh/ip",
         "status": "unstable",
-        "sid": "60096"
+	"sid": "60107"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh/port",
         "status": "unstable",
-        "sid": "60097"
+	"sid": "60108"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/ssh/ssh/username",
         "status": "unstable",
-        "sid": "60098"
+	"sid": "60109"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls",
         "status": "unstable",
-        "sid": "60099"
+	"sid": "60110"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls/tls",
         "status": "unstable",
-        "sid": "60100"
+	"sid": "60111"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/client-fingerprint",
         "status": "unstable",
-        "sid": "60101"
+	"sid": "60112"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/ip",
         "status": "unstable",
-        "sid": "60102"
+	"sid": "60113"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/port",
         "status": "unstable",
-        "sid": "60103"
+	"sid": "60114"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/server-fingerprint",
         "status": "unstable",
-        "sid": "60104"
+	"sid": "60115"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/tls/tls/server-identity",
         "status": "unstable",
-        "sid": "60105"
+	"sid": "60116"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/udp",
         "status": "unstable",
-        "sid": "60106"
+	"sid": "60117"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/udp/udp",
         "status": "unstable",
-        "sid": "60107"
+	"sid": "60118"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/udp/udp/ip",
         "status": "unstable",
-        "sid": "60108"
+	"sid": "60119"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/udp/udp/port",
         "status": "unstable",
-        "sid": "60109"
+	"sid": "60120"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/target/transport/udp/udp/prefix-length",
         "status": "unstable",
-        "sid": "60110"
+	"sid": "60121"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tlstm",
         "status": "unstable",
-        "sid": "60111"
+	"sid": "60122"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name",
         "status": "unstable",
-        "sid": "60112"
+	"sid": "60123"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/fingerprint",
         "status": "unstable",
-        "sid": "60113"
+	"sid": "60124"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/id",
         "status": "unstable",
-        "sid": "60114"
+	"sid": "60125"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/map-type",
         "status": "unstable",
-        "sid": "60115"
+	"sid": "60126"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tlstm/cert-to-name/name",
         "status": "unstable",
-        "sid": "60116"
+	"sid": "60127"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tsm",
         "status": "unstable",
-        "sid": "60117"
+	"sid": "60128"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/tsm/use-prefix",
         "status": "unstable",
-        "sid": "60118"
+	"sid": "60129"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm",
         "status": "unstable",
-        "sid": "60119"
+	"sid": "60130"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local",
         "status": "unstable",
-        "sid": "60120"
+	"sid": "60131"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user",
         "status": "unstable",
-        "sid": "60121"
+	"sid": "60132"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth",
         "status": "unstable",
-        "sid": "60122"
+	"sid": "60133"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol",
         "status": "unstable",
-        "sid": "60123"
+	"sid": "60134"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/md5",
         "status": "unstable",
-        "sid": "60124"
+	"sid": "60135"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/md5/md5",
         "status": "unstable",
-        "sid": "60125"
+	"sid": "60136"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/md5/md5/key",
         "status": "unstable",
-        "sid": "60126"
+	"sid": "60137"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/sha",
         "status": "unstable",
-        "sid": "60127"
+	"sid": "60138"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/sha/sha",
         "status": "unstable",
-        "sid": "60128"
+	"sid": "60139"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/auth/protocol/sha/sha/key",
         "status": "unstable",
-        "sid": "60129"
+	"sid": "60140"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/name",
         "status": "unstable",
-        "sid": "60130"
+	"sid": "60141"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv",
         "status": "unstable",
-        "sid": "60131"
+	"sid": "60142"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol",
         "status": "unstable",
-        "sid": "60132"
+	"sid": "60143"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/aes",
         "status": "unstable",
-        "sid": "60133"
+	"sid": "60144"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/aes/aes",
         "status": "unstable",
-        "sid": "60134"
+	"sid": "60145"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/aes/aes/key",
         "status": "unstable",
-        "sid": "60135"
+	"sid": "60146"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/des",
         "status": "unstable",
-        "sid": "60136"
+	"sid": "60147"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/des/des",
         "status": "unstable",
-        "sid": "60137"
+	"sid": "60148"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/local/user/priv/protocol/des/des/key",
         "status": "unstable",
-        "sid": "60138"
+	"sid": "60149"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote",
         "status": "unstable",
-        "sid": "60139"
+	"sid": "60150"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/engine-id",
         "status": "unstable",
-        "sid": "60140"
+	"sid": "60151"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user",
         "status": "unstable",
-        "sid": "60141"
+	"sid": "60152"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth",
         "status": "unstable",
-        "sid": "60142"
+	"sid": "60153"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol",
         "status": "unstable",
-        "sid": "60143"
+	"sid": "60154"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/md5",
         "status": "unstable",
-        "sid": "60144"
+	"sid": "60155"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/md5/md5",
         "status": "unstable",
-        "sid": "60145"
+	"sid": "60156"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/md5/md5/key",
         "status": "unstable",
-        "sid": "60146"
+	"sid": "60157"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/sha",
         "status": "unstable",
-        "sid": "60147"
+	"sid": "60158"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/sha/sha",
         "status": "unstable",
-        "sid": "60148"
+	"sid": "60159"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/auth/protocol/sha/sha/key",
         "status": "unstable",
-        "sid": "60149"
+	"sid": "60160"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/name",
         "status": "unstable",
-        "sid": "60150"
+	"sid": "60161"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv",
         "status": "unstable",
-        "sid": "60151"
+	"sid": "60162"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol",
         "status": "unstable",
-        "sid": "60152"
+	"sid": "60163"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/aes",
         "status": "unstable",
-        "sid": "60153"
+	"sid": "60164"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/aes/aes",
         "status": "unstable",
-        "sid": "60154"
+	"sid": "60165"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/aes/aes/key",
         "status": "unstable",
-        "sid": "60155"
+	"sid": "60166"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/des",
         "status": "unstable",
-        "sid": "60156"
+        "sid": "60167"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/des/des",
         "status": "unstable",
-        "sid": "60157"
+	"sid": "60168"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/usm/remote/user/priv/protocol/des/des/key",
         "status": "unstable",
-        "sid": "60158"
+	"sid": "60169"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm",
         "status": "unstable",
-        "sid": "60159"
+	"sid": "60170"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group",
         "status": "unstable",
-        "sid": "60160"
+	"sid": "60171"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access",
         "status": "unstable",
-        "sid": "60161"
+	"sid": "60172"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/context",
         "status": "unstable",
-        "sid": "60162"
+	"sid": "60173"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/context-match",
         "status": "unstable",
-        "sid": "60163"
+	"sid": "60174"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/notify-view",
         "status": "unstable",
-        "sid": "60164"
+	"sid": "60175"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/read-view",
         "status": "unstable",
-        "sid": "60165"
+	"sid": "60176"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/security-level",
         "status": "unstable",
-        "sid": "60166"
+	"sid": "60177"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/security-model",
         "status": "unstable",
-        "sid": "60167"
+	"sid": "60178"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/access/write-view",
         "status": "unstable",
-        "sid": "60168"
+	"sid": "60179"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/member",
         "status": "unstable",
-        "sid": "60169"
+	"sid": "60180"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/member/security-model",
         "status": "unstable",
-        "sid": "60170"
+	"sid": "60181"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/member/security-name",
         "status": "unstable",
-        "sid": "60171"
+	"sid": "60182"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/group/name",
         "status": "unstable",
-        "sid": "60172"
+	"sid": "60183"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/view",
         "status": "unstable",
-        "sid": "60173"
+	"sid": "60184"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/view/exclude",
         "status": "unstable",
-        "sid": "60174"
+	"sid": "60185"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/view/include",
         "status": "unstable",
-        "sid": "60175"
+	"sid": "60186"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-snmp:snmp/vacm/view/name",
         "status": "unstable",
-        "sid": "60176"
+	"sid": "60187"
       }
     ]
   }

--- a/test/test_sid/test-40-expected-output.txt
+++ b/test/test_sid/test-40-expected-output.txt
@@ -1,0 +1,1 @@
+ERROR, .sid files can be only generated for YANG modules. Generation of .sid files for YANG submodules is prohibited.


### PR DESCRIPTION
Summary of changes:

- Fixed SID item identifier paths for nodes defined in YANG submodules.
    Reported by Andy Bierman on IETF CoRE mailing list. The initial report [is here](https://mailarchive.ietf.org/arch/msg/yang-tooling/y-N3rNALEe9Zm99AczFzT44LueI/).
- Corrected behavior of generation of .sid files for YANG submodules.
    Related to previous point.