### PR TITLE
Plugin sid: Unify updated 'dependency-revision' list

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -888,11 +888,17 @@ class SidFile:
 
     ########################################################
     # Create list of dependent module with optional revision
+    # Call only after validate_dep_revisions()
     def build_dependencies(self, module):
         imports = module.search('import')
 
         if 'dependency-revision' not in self.content and len(imports) > 0:
             self.content['dependency-revision'] = []
+
+        dep_unification = {}
+        for dep in self.content.get('dependency-revision', []):
+            # the deps are already checked
+            dep_unification[dep['module-name']] = dep
 
         for import_stmt in imports:
             dep = collections.OrderedDict()
@@ -934,7 +940,7 @@ class SidFile:
                         latest = r[0]
 
                 if latest == '':
-                    raise Exception(f'The .sid file requires the imported ' +
+                    raise SidFileError(f'The .sid file requires the imported ' +
                     'modules to have revision statement. No module ' +
                     '"{module_name}" with revision statement found.')
 
@@ -948,7 +954,11 @@ class SidFile:
                     "'ietf-sid-file:sid-file/dependency-revision/module-revision'.") # noqa: E501
 
             dep['module-revision'] = revision
-            self.content['dependency-revision'].append(dep)
+            old_dep = dep_unification.get(module_name)
+            if old_dep is not None and (old_rev := old_dep['module-revision']) > revision:
+                raise SidFileError(f"Module {module_name} is imported with older revision in YANG ({revision}) than in the .sid file ({old_rev})")
+            dep_unification[module_name] = dep
+        self.content['dependency-revision'] = sorted(dep_unification.values(), key=lambda d: d['module-name'])
 
     ########################################################
     # Sort the items list by 'namespace' and 'identifier'

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -2,10 +2,12 @@ PYANG?= pyang
 
 .PHONY: test test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 test23 \
-	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34 \
+	test37 test38
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 \
-	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 \
+	test33 test34 test37 test38
 
 test1:
 	# Test help
@@ -196,3 +198,26 @@ test34: aug-a@2025-08-25.yang aug-b@2025-08-25.yang aug-c@2025-08-25.yang test-3
 	diff -b aug-c@2025-08-25.sid test-34-expected-aug-c.sid
 	rm aug-a@2025-08-25.sid aug-b@2025-08-25.sid aug-c@2025-08-25.sid
 
+test37: update-a@2026-02-10.yang update-a@2026-02-15.yang update-b@2026-02-10.yang update-b@2026-02-15.yang update-b@2026-02-20.yang
+	# Test dependency unification
+	$(PYANG) --sid-generate-file 61000:1000 update-b@2026-02-10.yang >/dev/null
+	diff -b update-b@2026-02-10.sid test-37-expected-update-b@2026-02-10.sid
+	$(PYANG) --sid-update-file update-b@2026-02-10.sid update-b@2026-02-15.yang >/dev/null
+	diff -b update-b@2026-02-15.sid test-37-expected-update-b@2026-02-15.sid
+	$(PYANG) --sid-update-file update-b@2026-02-15.sid update-b@2026-02-20.yang >/dev/null
+	diff -b update-b@2026-02-20.sid test-37-expected-update-b@2026-02-20.sid
+	rm update-b@2026-02-10.sid update-b@2026-02-15.sid update-b@2026-02-20.sid
+
+test38: update-a@2026-02-10.yang update-a@2026-02-15.yang update-b@2026-02-10.yang update-b@2026-02-15.yang update-b@2026-02-20.yang
+	# Test dependency unification
+	rm -f update-b@2026-02-15.sid update-b@2026-02-20.sid
+	$(PYANG) --sid-generate-file 61000:1000 update-b@2026-02-10.yang >/dev/null
+	$(PYANG) --sid-update-file update-b@2026-02-10.sid update-b@2026-02-15.yang >/dev/null
+	sed -i 's/"module-revision": "2026-02-10"/"module-revision": "2026-02-16"/' update-b@2026-02-15.sid
+	$(PYANG) --sid-update-file update-b@2026-02-15.sid update-b@2026-02-20.yang 2>&1 | diff -b test-38-expected-output-1.txt -
+	test ! -f update-b@2026-02-20.sid
+	rm update-b@2026-02-15.sid
+	sed -i 's/"module-revision": "2026-02-10"/"module-revision": "2026-02-11"/' update-b@2026-02-10.sid
+	$(PYANG) --sid-update-file update-b@2026-02-10.sid update-b@2026-02-15.yang 2>&1 | diff -b test-38-expected-output-2.txt -
+	test ! -f update-b@2026-02-15.sid
+	rm update-b@2026-02-10.sid

--- a/test/test_sid/test-1-expected-output.txt
+++ b/test/test_sid/test-1-expected-output.txt
@@ -62,6 +62,11 @@ OPTIONS
 
   $ pyang --sid-check-file toaster@2009-12-28.sid toaster@2009-12-28.yang
 
+--sid-extension
+
+   Add non standard entries in the .sid file to facilitate CORECONF manipulation
+   on constrained devices. 
+
 --sid-list
 
   The --sid-list option can be used before any of the previous options to

--- a/test/test_sid/test-20-expected-ieee802-dot1q-psfp@2020-07-07.sid
+++ b/test/test_sid/test-20-expected-ieee802-dot1q-psfp@2020-07-07.sid
@@ -5,16 +5,16 @@
     "sid-file-status": "unpublished",
     "dependency-revision": [
       {
-        "module-name": "ieee802-dot1q-types",
-        "module-revision": "2018-03-07"
-      },
-      {
         "module-name": "ieee802-dot1q-bridge",
         "module-revision": "2020-11-06"
       },
       {
         "module-name": "ieee802-dot1q-stream-filters-gates",
         "module-revision": "2020-11-06"
+      },
+      {
+        "module-name": "ieee802-dot1q-types",
+        "module-revision": "2018-03-07"
       }
     ],
     "assignment-range": [

--- a/test/test_sid/test-23-expected-example-module-aug.sid
+++ b/test/test_sid/test-23-expected-example-module-aug.sid
@@ -4,11 +4,11 @@
     "sid-file-status": "unpublished",
     "dependency-revision": [
       {
-        "module-name": "ietf-yang-structure-ext",
+        "module-name": "example-module",
         "module-revision": "2020-06-17"
       },
       {
-        "module-name": "example-module",
+        "module-name": "ietf-yang-structure-ext",
         "module-revision": "2020-06-17"
       }
     ],

--- a/test/test_sid/test-24-expected-ietf-system@2014-08-06.sid
+++ b/test/test_sid/test-24-expected-ietf-system@2014-08-06.sid
@@ -4,8 +4,8 @@
     "module-revision": "2014-08-06",
     "dependency-revision": [
       {
-        "module-name": "ietf-yang-types",
-        "module-revision": "2013-07-15"
+        "module-name": "iana-crypt-hash",
+        "module-revision": "2014-08-06"
       },
       {
         "module-name": "ietf-inet-types",
@@ -16,8 +16,8 @@
         "module-revision": "2018-02-14"
       },
       {
-        "module-name": "iana-crypt-hash",
-        "module-revision": "2014-08-06"
+        "module-name": "ietf-yang-types",
+        "module-revision": "2013-07-15"
       }
     ],
     "assignment-range": [

--- a/test/test_sid/test-37-expected-update-b@2026-02-10.sid
+++ b/test/test_sid/test-37-expected-update-b@2026-02-10.sid
@@ -1,0 +1,51 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "update-b",
+    "module-revision": "2026-02-10",
+    "sid-file-status": "unpublished",
+    "dependency-revision": [
+      {
+        "module-name": "update-a",
+        "module-revision": "2026-02-10"
+      }
+    ],
+    "assignment-range": [
+      {
+        "entry-point": "61000",
+        "size": "1000"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "update-b",
+        "status": "unstable",
+        "sid": "61000"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "advanced-table",
+        "status": "unstable",
+        "sid": "61001"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace",
+        "status": "unstable",
+        "sid": "61002"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/number-of-tables",
+        "status": "unstable",
+        "sid": "61003"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/tables-type",
+        "status": "unstable",
+        "sid": "61004"
+      }
+    ]
+  }
+}

--- a/test/test_sid/test-37-expected-update-b@2026-02-15.sid
+++ b/test/test_sid/test-37-expected-update-b@2026-02-15.sid
@@ -1,0 +1,58 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "update-b",
+    "module-revision": "2026-02-15",
+    "sid-file-version": 1,
+    "sid-file-status": "unpublished",
+    "dependency-revision": [
+      {
+        "module-name": "update-a",
+        "module-revision": "2026-02-10"
+      }
+    ],
+    "assignment-range": [
+      {
+        "entry-point": "61000",
+        "size": "1000"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "update-b",
+        "status": "unstable",
+        "sid": "61000"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "advanced-table",
+        "status": "unstable",
+        "sid": "61001"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace",
+        "status": "unstable",
+        "sid": "61002"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/number-of-tables",
+        "status": "unstable",
+        "sid": "61003"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/tables-type",
+        "status": "unstable",
+        "sid": "61004"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/misc",
+        "status": "unstable",
+        "sid": "61005"
+      }
+    ]
+  }
+}

--- a/test/test_sid/test-37-expected-update-b@2026-02-20.sid
+++ b/test/test_sid/test-37-expected-update-b@2026-02-20.sid
@@ -1,0 +1,64 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "update-b",
+    "module-revision": "2026-02-20",
+    "sid-file-version": 2,
+    "sid-file-status": "unpublished",
+    "dependency-revision": [
+      {
+        "module-name": "update-a",
+        "module-revision": "2026-02-15"
+      }
+    ],
+    "assignment-range": [
+      {
+        "entry-point": "61000",
+        "size": "1000"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "update-b",
+        "status": "unstable",
+        "sid": "61000"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "advanced-table",
+        "status": "unstable",
+        "sid": "61001"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace",
+        "status": "unstable",
+        "sid": "61002"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/number-of-tables",
+        "status": "unstable",
+        "sid": "61003"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/tables-type",
+        "status": "unstable",
+        "sid": "61004"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/misc",
+        "status": "unstable",
+        "sid": "61005"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/update-b:workplace/number-of-chairs",
+        "status": "unstable",
+        "sid": "61006"
+      }
+    ]
+  }
+}

--- a/test/test_sid/test-38-expected-output-1.txt
+++ b/test/test_sid/test-38-expected-output-1.txt
@@ -1,0 +1,1 @@
+ERROR in 'update-b@2026-02-15.sid', Module update-a is imported with older revision in YANG (2026-02-15) than in the .sid file (2026-02-16)

--- a/test/test_sid/test-38-expected-output-2.txt
+++ b/test/test_sid/test-38-expected-output-2.txt
@@ -1,0 +1,1 @@
+ERROR in 'update-b@2026-02-10.sid', Module update-a is imported with older revision in YANG (2026-02-10) than in the .sid file (2026-02-11)

--- a/test/test_sid/update-a@2026-02-10.yang
+++ b/test/test_sid/update-a@2026-02-10.yang
@@ -1,0 +1,18 @@
+module update-a {
+  yang-version 1.1;
+  namespace "http://example.com/update-a";
+  prefix udp-a;
+  
+  revision 2026-02-10; 
+
+  identity table-type;
+  identity basic-table {
+    base table-type;
+  }
+
+  container table {
+    leaf surface {
+      type uint32;
+    }
+  }
+}

--- a/test/test_sid/update-a@2026-02-15.yang
+++ b/test/test_sid/update-a@2026-02-15.yang
@@ -1,0 +1,29 @@
+module update-a {
+  yang-version 1.1;
+  namespace "http://example.com/update-a";
+  prefix udp-a;
+  
+  revision 2026-02-15;
+  revision 2026-02-10; 
+
+  identity table-type;
+  identity basic-table {
+    base table-type;
+  }
+
+  container table {
+    leaf surface {
+      type uint32;
+    }
+
+    leaf height {
+      type uint32;
+    }
+  }
+
+  container chair {
+    leaf height {
+      type uint32;
+    }
+  }
+}

--- a/test/test_sid/update-b@2026-02-10.yang
+++ b/test/test_sid/update-b@2026-02-10.yang
@@ -1,0 +1,28 @@
+module update-b {
+  yang-version 1.1;
+  namespace "http://example.com/update-b";
+  prefix udp-b;
+
+  import update-a {
+    prefix udp-a;
+    revision-date 2026-02-10;
+  }
+
+  revision 2026-02-10;
+
+  identity advanced-table {
+    base udp-a:table-type;
+  } 
+
+  container workplace {
+    leaf number-of-tables {
+      type uint32;
+    }
+
+    leaf tables-type {
+      type identityref {
+        base udp-a:table-type;
+      }
+    }
+  }
+}

--- a/test/test_sid/update-b@2026-02-15.yang
+++ b/test/test_sid/update-b@2026-02-15.yang
@@ -1,0 +1,33 @@
+module update-b {
+  yang-version 1.1;
+  namespace "http://example.com/update-b";
+  prefix udp-b;
+
+  import update-a {
+    prefix udp-a;
+    revision-date 2026-02-10;
+  }
+ 
+  revision 2026-02-15;
+  revision 2026-02-10;
+
+  identity advanced-table {
+    base udp-a:table-type;
+  }
+  
+  container workplace {
+    leaf number-of-tables {
+      type uint32;
+    }
+
+    leaf tables-type {
+      type identityref {
+        base udp-a:table-type;
+      }
+    }
+
+    leaf misc {
+      type string;
+    }
+  }
+}

--- a/test/test_sid/update-b@2026-02-20.yang
+++ b/test/test_sid/update-b@2026-02-20.yang
@@ -1,0 +1,38 @@
+module update-b {
+  yang-version 1.1;
+  namespace "http://example.com/update-b";
+  prefix udp-b;
+
+  import update-a {
+    prefix udp-a;
+    revision-date 2026-02-15;
+  }
+  
+  revision 2026-02-20;
+  revision 2026-02-15;
+  revision 2026-02-10;
+
+  identity advanced-table {
+    base udp-a:table-type;
+  }
+
+  container workplace {
+    leaf number-of-tables {
+      type uint32;
+    }
+
+    leaf number-of-chairs {
+      type uint32;
+    }
+
+    leaf tables-type {
+      type identityref {
+        base udp-a:table-type;
+      }
+    }
+
+    leaf misc {
+      type string;
+    }
+  }
+}


### PR DESCRIPTION

Summary of changes:

- Fix issue with duplicit same module with same or different revision in the 'dependency-revision' list. Reported https://github.com/core-wg/pyang/issues/17
- The 'dependency-revision' list is now correctly sorted.